### PR TITLE
Added methods for pausing and resuming a Timer. Closes #44

### DIFF
--- a/src/main/java/com/github/hanyaeger/api/engine/Timer.java
+++ b/src/main/java/com/github/hanyaeger/api/engine/Timer.java
@@ -13,6 +13,7 @@ public abstract class Timer {
 
     private final long interval;
     private long prevTime = 0;
+    private boolean active = true;
 
     /**
      * Create a new instance of {@link Timer} for the given interval in milliseconds.
@@ -24,6 +25,7 @@ public abstract class Timer {
     }
 
     protected void handle(final long now) {
+        if (!active) return;
 
         if (prevTime == 0) {
             prevTime = now;
@@ -36,6 +38,20 @@ public abstract class Timer {
         prevTime = now;
 
         onAnimationUpdate(now);
+    }
+
+    /**
+     * Pause the timer so it will no longer update with each animation.
+     */
+    public final void pause() {
+        active = false;
+    }
+
+    /**
+     * Resume the timer so it will start updating on each animation again.
+     */
+    public final void resume() {
+        active = true;
     }
 
     /**

--- a/src/test/java/com/github/hanyaeger/api/engine/TimerTest.java
+++ b/src/test/java/com/github/hanyaeger/api/engine/TimerTest.java
@@ -43,6 +43,35 @@ class TimerTest {
         Assertions.assertTrue(timer.updateCalled);
     }
 
+    @Test
+    void handleDoesNotCallOnAnimationUpdateIfTimerIsPaused() {
+        // Arrange
+        var timer = new TimerTest.TimerImpl(1000);
+
+        // Act
+        timer.handle(1);
+        timer.pause();
+        timer.handle(1500 * 1_000_000);
+
+        // Assert
+        Assertions.assertFalse(timer.updateCalled);
+    }
+
+    @Test
+    void handleCallsOnAnimationUpdateIfTimerIsResumed() {
+        // Arrange
+        var timer = new TimerTest.TimerImpl(1000);
+
+        // Act
+        timer.handle(1);
+        timer.pause();
+        timer.resume();
+        timer.handle(1500 * 1_000_000);
+
+        // Assert
+        Assertions.assertTrue(timer.updateCalled);
+    }
+
     private class TimerImpl extends Timer {
 
         private boolean updateCalled = false;


### PR DESCRIPTION
Issue #44 suggests creating a new implementation of the Timer class that can be paused and resumed. However, I think this should be basic functionality of the Timer and moving it to a seperate implementation only bloats the API.