### PR TITLE
Fixed NullPointerException because of missing config in splash screen. Fixes #153

### DIFF
--- a/src/main/java/com/github/hanyaeger/api/engine/scenes/SceneCollection.java
+++ b/src/main/java/com/github/hanyaeger/api/engine/scenes/SceneCollection.java
@@ -138,6 +138,7 @@ public class SceneCollection extends LinkedHashMap<Integer, YaegerScene> impleme
             this.finishedSplashScreen = true;
             activateFirstScene();
         });
+        splash.setConfig(yaegerConfig);
         splash.init(injector);
         splash.setStage(stage);
         activate(splash);


### PR DESCRIPTION
Because the splash scene has it's own factory and is not added using the addScene method, it's config field won't be set which will result in a NullPointerException.

