### PR TITLE
Refactored YaegerCommandLineParser and checked for invalid command line arguments. Closes #156

### DIFF
--- a/src/test/java/com/github/hanyaeger/api/engine/YaegerCommandLineParserTest.java
+++ b/src/test/java/com/github/hanyaeger/api/engine/YaegerCommandLineParserTest.java
@@ -54,4 +54,21 @@ class YaegerCommandLineParserTest {
         assertTrue(output.contains("--noSplash"));
         assertTrue(output.contains("--help"));
     }
+
+    @Test
+    void invalidArgumentPrintsWarning() {
+        // Arrange
+        var sut = new YaegerCommandLineParser();
+        var invalidArgs = Arrays.asList("--foo");
+
+        var ba = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(ba));
+
+        // Act
+        var actual = sut.parseToConfig(invalidArgs);
+
+        // Assert
+        String output = ba.toString();
+        assertTrue(output.contains("--foo"));
+    }
 }


### PR DESCRIPTION
- Refactored YaegerCommandLineParser to make it easier to add new command line arguments
- Checked for invalid command line arguments and displayed a warning

Whenever an invalid command line argument is used, it will print a warning and also show the help screen with the valid command line argument.

Not entirely sure whether this use of an enum is clean, so I would love some feedback on this PR.