### PR TITLE
Added support for configurable entities in tilemaps

### DIFF
--- a/src/main/java/com/github/hanyaeger/api/engine/entities/tilemap/EntityConfiguration.java
+++ b/src/main/java/com/github/hanyaeger/api/engine/entities/tilemap/EntityConfiguration.java
@@ -1,0 +1,39 @@
+package com.github.hanyaeger.api.engine.entities.tilemap;
+
+import com.github.hanyaeger.api.engine.entities.entity.YaegerEntity;
+
+/**
+ * A wrapper class that allows entities to be configured using a generic configuration object.
+ *  * This configuration object can be passed to the entity's constructor for custom configuration.
+ * @param <C> the type of the configuration object
+ */
+class EntityConfiguration<C> {
+
+    private Class<? extends YaegerEntity> entityClass;
+    private C configuration;
+
+    EntityConfiguration(Class<? extends YaegerEntity> entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    EntityConfiguration(Class<? extends YaegerEntity> entityClass, C configuration) {
+        this(entityClass);
+        this.configuration = configuration;
+    }
+
+    Class<? extends YaegerEntity> getEntityClass() {
+        return entityClass;
+    }
+
+    void setEntityClass(Class<? extends YaegerEntity> entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    C getConfiguration() {
+        return configuration;
+    }
+
+    void setConfiguration(C configuration) {
+        this.configuration = configuration;
+    }
+}

--- a/src/main/java/com/github/hanyaeger/api/engine/entities/tilemap/TileFactory.java
+++ b/src/main/java/com/github/hanyaeger/api/engine/entities/tilemap/TileFactory.java
@@ -15,21 +15,21 @@ import java.lang.reflect.InvocationTargetException;
  * {@link TileMap}. For such instances, only a {@link Class}, its {@link Coordinate2D} and its {@link Size}
  * will be supplied, after which a {@link TileFactory} will be responsible for creating instances.
  * <p>
- * A {@link YaegerEntity} created by the {@link TileFactory} will most likely n not be square shaped. In case of
- * a {@link SpriteEntity}, its aspect ratio will not be preserver.
+ * A {@link YaegerEntity} created by the {@link TileFactory} will most likely not be square shaped. In case of
+ * a {@link SpriteEntity}, its aspect ratio will not be preserved.
  */
 public class TileFactory {
 
     private static final String MESSAGE_INVALID_CONSTRUCTOR_EXCEPTION = "An Entity used for a Tilemap should have a constructor that accepts" +
-            " two parameters: An instance of Coordinate2D and of Size. Configurable entities should have a third parameter for the" +
-            " configuration object.";
+            " two parameters: An instance of Coordinate2D and of Size.";
+    private static final String MESSAGE_INVALID_CONFIGURABLE_ENTITY = "Configurable entity %s should also accept an instance of %s as third parameter.";
     private static final String MESSAGE_FAILED_TO_INSTANTIATE_ENTITY = "Unable to instantiate an Entity for the TileMap";
 
-    public <C extends Object> YaegerEntity create(final EntityConfiguration<C> entityConfiguration, final Coordinate2D location, final Size size) {
+    public <C> YaegerEntity create(final EntityConfiguration<C> entityConfiguration, final Coordinate2D location, final Size size) {
         YaegerEntity entity;
 
-        Constructor<? extends YaegerEntity> declaredConstructor = getDeclaredConstructor(entityConfiguration);
-        C configuration = entityConfiguration.getConfiguration();
+        var declaredConstructor = getDeclaredConstructor(entityConfiguration);
+        var configuration = entityConfiguration.getConfiguration();
         try {
             if (configuration != null) {
                 entity = declaredConstructor.newInstance(location, size, configuration);
@@ -51,11 +51,11 @@ public class TileFactory {
         return create(new EntityConfiguration<>(entityClass), location, size);
     }
 
-    private <C extends Object> Constructor<? extends YaegerEntity> getDeclaredConstructor(EntityConfiguration<C> entityConfiguration) {
-        Class<? extends YaegerEntity> entityClass = entityConfiguration.getEntityClass();
-        C configuration = entityConfiguration.getConfiguration();
+    private <C> Constructor<? extends YaegerEntity> getDeclaredConstructor(EntityConfiguration<C> entityConfiguration) {
+        var entityClass = entityConfiguration.getEntityClass();
+        var configuration = entityConfiguration.getConfiguration();
 
-        Constructor<? extends YaegerEntity> declaredConstructor = null;
+        Constructor<? extends YaegerEntity> declaredConstructor;
         try {
             if (configuration != null) {
                 declaredConstructor = entityClass.getDeclaredConstructor(Coordinate2D.class, Size.class, configuration.getClass());
@@ -63,7 +63,11 @@ public class TileFactory {
                 declaredConstructor = entityClass.getDeclaredConstructor(Coordinate2D.class, Size.class);
             }
         } catch (NoSuchMethodException e) {
-            throw new InvalidConstructorException(MESSAGE_INVALID_CONSTRUCTOR_EXCEPTION, e);
+            var message = MESSAGE_INVALID_CONSTRUCTOR_EXCEPTION;
+            if (configuration != null) {
+                message += String.format("\n" + MESSAGE_INVALID_CONFIGURABLE_ENTITY, entityClass.getSimpleName(), configuration.getClass().getSimpleName());
+            }
+            throw new InvalidConstructorException(message, e);
         }
 
         return declaredConstructor;

--- a/src/main/java/com/github/hanyaeger/api/engine/entities/tilemap/TileFactory.java
+++ b/src/main/java/com/github/hanyaeger/api/engine/entities/tilemap/TileFactory.java
@@ -63,13 +63,18 @@ public class TileFactory {
                 declaredConstructor = entityClass.getDeclaredConstructor(Coordinate2D.class, Size.class);
             }
         } catch (NoSuchMethodException e) {
-            var message = MESSAGE_INVALID_CONSTRUCTOR_EXCEPTION;
-            if (configuration != null) {
-                message += String.format("\n" + MESSAGE_INVALID_CONFIGURABLE_ENTITY, entityClass.getSimpleName(), configuration.getClass().getSimpleName());
-            }
-            throw new InvalidConstructorException(message, e);
+            throw new InvalidConstructorException(getInvalidConstructorMessage(entityConfiguration), e);
         }
 
         return declaredConstructor;
+    }
+
+    private <C> String getInvalidConstructorMessage(EntityConfiguration<C> ec) {
+        var message = MESSAGE_INVALID_CONSTRUCTOR_EXCEPTION;
+        if (ec.getConfiguration() != null) {
+            message += String.format("\n" + MESSAGE_INVALID_CONFIGURABLE_ENTITY,
+                    ec.getClass().getSimpleName(), ec.getConfiguration().getClass().getSimpleName());
+        }
+        return message;
     }
 }

--- a/src/main/java/com/github/hanyaeger/api/engine/entities/tilemap/TileMap.java
+++ b/src/main/java/com/github/hanyaeger/api/engine/entities/tilemap/TileMap.java
@@ -26,7 +26,7 @@ import java.util.*;
  */
 public abstract class TileMap extends EntitySupplier implements Anchorable, Activatable {
 
-    private final Map<Integer, Class<? extends YaegerEntity>> entities = new HashMap<>();
+    private final Map<Integer, EntityConfiguration> entities = new HashMap<>();
 
     private int[][] map;
     private transient TileFactory tileFactory;
@@ -95,7 +95,11 @@ public abstract class TileMap extends EntitySupplier implements Anchorable, Acti
      *                    a {@link Size}. If such a constructor is not present, an {@link YaegerEngineException} will be thrown.
      */
     public void addEntity(final int identifier, final Class<? extends YaegerEntity> entityClass) {
-        entities.put(identifier, entityClass);
+        entities.put(identifier, new EntityConfiguration(entityClass));
+    }
+
+    public <C extends Object> void addEntity(final int identifier, final Class<? extends YaegerEntity> entityClass, C configuration) {
+        entities.put(identifier, new EntityConfiguration(entityClass, configuration));
     }
 
     private void transformMapToEntities() {
@@ -123,13 +127,13 @@ public abstract class TileMap extends EntitySupplier implements Anchorable, Acti
                 if (key != 0) {
                     var entityWidth = width / map[i].length;
 
-                    var entityClass = entities.get(key);
+                    var entityConfiguration = entities.get(key);
 
-                    if (entityClass == null) {
+                    if (entityConfiguration == null) {
                         throw new EntityNotAvailableException("An Entity with key \"" + key + "\" has not been added to the TileMap.");
                     }
 
-                    var entity = tileFactory.create(entityClass,
+                    var entity = tileFactory.create(entityConfiguration,
                             new Coordinate2D(Math.round(x + (j * entityWidth)), Math.round(y + entityY)),
                             new Size(Math.ceil(entityWidth), Math.ceil(entityHeight)));
 
@@ -207,4 +211,5 @@ public abstract class TileMap extends EntitySupplier implements Anchorable, Acti
         result = 31 * result + Arrays.hashCode(map);
         return result;
     }
+
 }

--- a/src/test/java/com/github/hanyaeger/api/engine/entities/tilemap/TileFactoryTest.java
+++ b/src/test/java/com/github/hanyaeger/api/engine/entities/tilemap/TileFactoryTest.java
@@ -37,14 +37,25 @@ class TileFactoryTest {
     }
 
     @Test
-    void creatingEntityWithCrashingConstructorThrowsInvalidConstructorException() {
+    void creatingEntityWithCrashingConstructorThrowsFailedToInstantiate() {
         // Arrange
 
         // Act
-        var failedToInstantiateEntityException = assertThrows(FailedToInstantiateEntityException.class, () -> sut.create(SpriteEntityCrashingConstructorImpl.class, DEFAULT_LOCATION, DEFAULT_SIZE));
+        var failedToInstantiateEntityException = assertThrows(FailedToInstantiateEntityException.class,
+                () -> sut.create(SpriteEntityCrashingConstructorImpl.class, DEFAULT_LOCATION, DEFAULT_SIZE));
 
         // Assert
         assertTrue(failedToInstantiateEntityException.getCause() instanceof InvocationTargetException);
+    }
+
+    @Test
+    void creatingConfigurableEntityWithInvalidConfigurationTypeThrowsInvalidConstructorException() {
+        // Arrange
+        var entityConfiguration = new EntityConfiguration<Integer>(YaegerEntityConfigurableConstructorImpl.class, 1); // Type should be String
+
+        // Act & Assert
+        var invalidConstructorException = assertThrows(InvalidConstructorException.class,
+                () -> sut.create(entityConfiguration, new Coordinate2D(1, 1), new Size(1, 1)));
     }
 
     @Test
@@ -67,5 +78,29 @@ class TileFactoryTest {
 
         // Assert
         assertFalse(((SpriteEntityValidConstructorImpl) entity).isPreserveAspectRatio());
+    }
+
+    @Test
+    void entityWithConfigurationObjectShouldCallOverloadedConstructor() {
+        // Arrange
+        var entityConfiguration = new EntityConfiguration<String>(YaegerEntityConfigurableConstructorImpl.class, "sprite");
+
+        // Act
+        var entity = sut.create(entityConfiguration, new Coordinate2D(1, 1), new Size(1, 1));
+
+        // Assert
+        assertTrue(((YaegerEntityConfigurableConstructorImpl) entity).configurableConstructorCalled);
+    }
+
+    @Test
+    void entityWithoutConfigurationObjectShouldNotCallOverloadedConstructor() {
+        // Arrange
+        var entityConfiguration = new EntityConfiguration<String>(YaegerEntityConfigurableConstructorImpl.class);
+
+        // Act
+        var entity = sut.create(entityConfiguration, new Coordinate2D(1, 1), new Size(1, 1));
+
+        // Assert
+        assertFalse(((YaegerEntityConfigurableConstructorImpl) entity).configurableConstructorCalled);
     }
 }

--- a/src/test/java/com/github/hanyaeger/api/engine/entities/tilemap/TileMapTest.java
+++ b/src/test/java/com/github/hanyaeger/api/engine/entities/tilemap/TileMapTest.java
@@ -147,7 +147,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -184,7 +184,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -223,7 +223,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -231,7 +231,7 @@ class TileMapTest {
         localSut.activate();
 
         // Assert
-        verify(tileFactory, times(9)).create(any(), any(), any());
+        verify(tileFactory, times(9)).create(any(EntityConfiguration.class), any(), any());
     }
 
     @Test
@@ -260,7 +260,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -289,7 +289,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -298,7 +298,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Size> argument = ArgumentCaptor.forClass(Size.class);
-        verify(tileFactory).create(any(), any(), argument.capture());
+        verify(tileFactory).create(any(EntityConfiguration.class), any(), argument.capture());
         assertEquals(SIZE.getHeight(), argument.getValue().getHeight());
         assertEquals(SIZE.getWidth(), argument.getValue().getWidth());
     }
@@ -337,7 +337,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -346,7 +346,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Size> argument = ArgumentCaptor.forClass(Size.class);
-        verify(tileFactory).create(any(), any(), argument.capture());
+        verify(tileFactory).create(any(EntityConfiguration.class), any(), argument.capture());
         assertEquals(Math.ceil(SIZE.getHeight() / 3), argument.getValue().getHeight());
         assertEquals(Math.ceil(SIZE.getWidth() / 3), argument.getValue().getWidth());
     }
@@ -372,7 +372,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -381,7 +381,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Size> argument = ArgumentCaptor.forClass(Size.class);
-        verify(tileFactory).create(any(), any(), argument.capture());
+        verify(tileFactory).create(any(EntityConfiguration.class), any(), argument.capture());
         assertEquals(Math.ceil(SIZE.getHeight() / 3), argument.getValue().getHeight());
         assertEquals(SIZE.getWidth(), argument.getValue().getWidth());
     }
@@ -409,7 +409,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -418,7 +418,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory).create(any(), argument.capture(), any());
+        verify(tileFactory).create(any(EntityConfiguration.class), argument.capture(), any());
         assertEquals(LOCATION.getX(), argument.getValue().getX());
         assertEquals(LOCATION.getY(), argument.getValue().getY());
     }
@@ -446,7 +446,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -455,7 +455,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory).create(any(), argument.capture(), any());
+        verify(tileFactory).create(any(EntityConfiguration.class), argument.capture(), any());
 
         var expectedX = LOCATION.getX() - SIZE.getWidth() / 2;
 
@@ -486,7 +486,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -495,7 +495,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory).create(any(), argument.capture(), any());
+        verify(tileFactory).create(any(EntityConfiguration.class), argument.capture(), any());
 
         var expectedX = LOCATION.getX() - SIZE.getWidth();
 
@@ -526,7 +526,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -535,7 +535,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory).create(any(), argument.capture(), any());
+        verify(tileFactory).create(any(EntityConfiguration.class), argument.capture(), any());
 
         var expectedX = LOCATION.getX();
         var expectedY = LOCATION.getY() - SIZE.getHeight() / 2;
@@ -567,7 +567,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -576,7 +576,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory).create(any(), argument.capture(), any());
+        verify(tileFactory).create(any(EntityConfiguration.class), argument.capture(), any());
 
         var expectedX = LOCATION.getX() - SIZE.getWidth() / 2;
         var expectedY = LOCATION.getY() - SIZE.getHeight() / 2;
@@ -608,7 +608,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -617,7 +617,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory).create(any(), argument.capture(), any());
+        verify(tileFactory).create(any(EntityConfiguration.class), argument.capture(), any());
 
         var expectedX = LOCATION.getX() - SIZE.getWidth();
         var expectedY = LOCATION.getY() - SIZE.getHeight() / 2;
@@ -651,7 +651,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -660,7 +660,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory).create(any(), argument.capture(), any());
+        verify(tileFactory).create(any(EntityConfiguration.class), argument.capture(), any());
 
         var expectedX = LOCATION.getX();
         var expectedY = LOCATION.getY() - SIZE.getHeight();
@@ -692,7 +692,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(EntityConfiguration.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -701,7 +701,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory).create(any(), argument.capture(), any());
+        verify(tileFactory).create(any(EntityConfiguration.class), argument.capture(), any());
 
         var expectedX = LOCATION.getX() - SIZE.getWidth() / 2;
         var expectedY = LOCATION.getY() - SIZE.getHeight();
@@ -733,7 +733,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         localSut.setTileFactory(tileFactory);
 
@@ -742,7 +742,7 @@ class TileMapTest {
 
         // Assert
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory).create(any(), argument.capture(), any());
+        verify(tileFactory).create(any(EntityConfiguration.class), argument.capture(), any());
 
         var expectedX = LOCATION.getX() - SIZE.getWidth();
         var expectedY = LOCATION.getY() - SIZE.getHeight();
@@ -775,7 +775,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         horizontalSut.setTileFactory(tileFactory);
 
@@ -785,7 +785,7 @@ class TileMapTest {
         // Assert
 
         ArgumentCaptor<Coordinate2D> argument = ArgumentCaptor.forClass(Coordinate2D.class);
-        verify(tileFactory, times(15)).create(any(), argument.capture(), any());
+        verify(tileFactory, times(15)).create(any(EntityConfiguration.class), argument.capture(), any());
 
         List<Coordinate2D> capturedCoordinates = argument.getAllValues();
 
@@ -820,7 +820,7 @@ class TileMapTest {
 
         var entity = mock(YaegerEntity.class);
         var tileFactory = mock(TileFactory.class);
-        when(tileFactory.create(any(), any(), any())).thenReturn(entity);
+        when(tileFactory.create(any(Class.class), any(), any())).thenReturn(entity);
 
         horizontalSut.setTileFactory(tileFactory);
 
@@ -830,7 +830,7 @@ class TileMapTest {
         // Assert
 
         ArgumentCaptor<Size> argument = ArgumentCaptor.forClass(Size.class);
-        verify(tileFactory, times(15)).create(any(), any(), argument.capture());
+        verify(tileFactory, times(15)).create(any(EntityConfiguration.class), any(), argument.capture());
 
         List<Size> capturedSizes = argument.getAllValues();
 
@@ -838,6 +838,35 @@ class TileMapTest {
             assertEquals(expectedWidth, capturedSizes.get(i).getWidth());
             assertEquals(expectedHeight, capturedSizes.get(i).getHeight());
         }
+    }
+
+    @Test
+    void addConfigurableEntityShouldCallTileFactoryWithEntityConfiguration() {
+        // Arrange
+        var configuredTileSut = new TileMap(LOCATION, SIZE) {
+            @Override
+            public void setupEntities() {
+                addEntity(1, YaegerEntity.class, "config");
+            }
+
+            @Override
+            public int[][] defineMap() {
+                return new int[][]{{1}};
+            }
+        };
+
+        var tileFactory = mock(TileFactory.class);
+        configuredTileSut.setTileFactory(tileFactory);
+        ArgumentCaptor<EntityConfiguration> argument = ArgumentCaptor.forClass(EntityConfiguration.class);
+
+        // Act
+        configuredTileSut.activate();
+
+        // Assert
+        verify(tileFactory, times(1)).create(argument.capture(), any(), any());
+        var entityConfiguration = argument.getValue();
+        assertEquals(YaegerEntity.class, entityConfiguration.getEntityClass());
+        assertEquals("config", entityConfiguration.getConfiguration());
     }
 
     private static class TileMapEmptyConstructorImpl extends TileMap {

--- a/src/test/java/com/github/hanyaeger/api/engine/entities/tilemap/YaegerEntityConfigurableConstructorImpl.java
+++ b/src/test/java/com/github/hanyaeger/api/engine/entities/tilemap/YaegerEntityConfigurableConstructorImpl.java
@@ -1,0 +1,27 @@
+package com.github.hanyaeger.api.engine.entities.tilemap;
+
+import com.github.hanyaeger.api.engine.Size;
+import com.github.hanyaeger.api.engine.entities.entity.Coordinate2D;
+import com.github.hanyaeger.api.engine.entities.entity.YaegerEntity;
+import javafx.scene.Node;
+
+import java.util.Optional;
+
+class YaegerEntityConfigurableConstructorImpl extends YaegerEntity {
+
+    boolean configurableConstructorCalled = false;
+
+    YaegerEntityConfigurableConstructorImpl(final Coordinate2D location, final Size size) {
+        super(location);
+    }
+
+    YaegerEntityConfigurableConstructorImpl(final Coordinate2D location, final Size size, String spriteName) {
+        super(location);
+        configurableConstructorCalled = true;
+    }
+
+    @Override
+    public Optional<? extends Node> getNode() {
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
Using the new addEntity(location, size, entityClass, config) method, different tiles with similar behavior can share the same tile class.

Some examples:

- 'Wall' tiles should all be colliders, but may have different sprites. These can be added using addEntity(location, size, WallTile.class, "sprites/wall_1.png").
- 'Corner' tiles all look the same, but should be rotated based on the corner they're in. Adding four different images for each corner is tedious. Here the config parameter could be the rotation: addEntity(location, size, CornerTile.class, 90).

After this PR has been merged, I will open a pull request to the showcase repo with some uses for this feature. Feedback is appreciated :)