### PR TITLE
Fix angleTo not working on the contents of a CompositeEntity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.han-yaeger</groupId>
     <artifactId>yaeger</artifactId>
-    <version>2020.2021-beta7-SNAPSHOT</version>
+    <version>2020.2021-beta6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>yaeger</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.han-yaeger</groupId>
     <artifactId>yaeger</artifactId>
-    <version>2020.2021-beta6-SNAPSHOT</version>
+    <version>2020.2021-beta7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>yaeger</name>
@@ -255,6 +255,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <version>5.6.2</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/github/hanyaeger/api/engine/entities/entity/YaegerEntity.java
+++ b/src/main/java/com/github/hanyaeger/api/engine/entities/entity/YaegerEntity.java
@@ -161,7 +161,7 @@ public abstract class YaegerEntity implements Initializable, TimerListProvider, 
         if (this.equals(entity)) {
             return 0d;
         }
-        return angleTo(entity.getAnchorLocation());
+        return angleTo(entity.getLocationInScene());
     }
 
     /**
@@ -188,11 +188,11 @@ public abstract class YaegerEntity implements Initializable, TimerListProvider, 
      */
     public double angleTo(final Coordinate2D otherLocation) {
 
-        if (getAnchorLocation().equals(otherLocation)) {
+        if (getLocationInScene().equals(otherLocation)) {
             return 0D;
         }
 
-        var delta = otherLocation.subtract(getAnchorLocation());
+        var delta = otherLocation.subtract(getLocationInScene());
         var normalizedDelta = delta.normalize();
         var angle = new Point2D(0, 1).angle(normalizedDelta);
 
@@ -351,5 +351,31 @@ public abstract class YaegerEntity implements Initializable, TimerListProvider, 
     @Override
     public RotationBuffer getRotationBuffer() {
         return rotationBuffer;
+    }
+
+    /**
+     * Calculate the absolute location of this {@link YaegerEntity} in the scene.
+     * Because {@link CompositeEntity} uses a relative coordinate system, this method is needed to make calculations
+     * for entities that are part of a {@link CompositeEntity}.
+     * @return a {@link Coordinate2D} with the absolute coordinates of the {@link YaegerEntity}.
+     */
+    protected Coordinate2D getLocationInScene() {
+        var boundsInScene = getNode()
+                .map(node -> node.localToScene(node.getBoundsInLocal(), true))
+                .orElse(EMPTY_BB);
+
+        var absoluteLocation = switch (getAnchorPoint()) {
+            case TOP_LEFT -> new Coordinate2D(boundsInScene.getMinX(), boundsInScene.getMinY());
+            case TOP_CENTER -> new Coordinate2D(boundsInScene.getCenterX(), boundsInScene.getMinY());
+            case TOP_RIGHT -> new Coordinate2D(boundsInScene.getMaxX(), boundsInScene.getMinY());
+            case CENTER_LEFT -> new Coordinate2D(boundsInScene.getMinX(), boundsInScene.getCenterY());
+            case CENTER_CENTER -> new Coordinate2D(boundsInScene.getCenterX(), boundsInScene.getCenterY());
+            case CENTER_RIGHT -> new Coordinate2D(boundsInScene.getMaxX(), boundsInScene.getCenterY());
+            case BOTTOM_LEFT -> new Coordinate2D(boundsInScene.getMinX(), boundsInScene.getMaxY());
+            case BOTTOM_CENTER -> new Coordinate2D(boundsInScene.getCenterX(), boundsInScene.getMaxY());
+            case BOTTOM_RIGHT -> new Coordinate2D(boundsInScene.getMaxX(), boundsInScene.getMaxY());
+        };
+
+        return absoluteLocation;
     }
 }

--- a/src/main/java/com/github/hanyaeger/api/engine/entities/entity/YaegerEntity.java
+++ b/src/main/java/com/github/hanyaeger/api/engine/entities/entity/YaegerEntity.java
@@ -364,7 +364,7 @@ public abstract class YaegerEntity implements Initializable, TimerListProvider, 
                 .map(node -> node.localToScene(node.getBoundsInLocal(), true))
                 .orElse(EMPTY_BB);
 
-        var absoluteLocation = switch (getAnchorPoint()) {
+        return switch (getAnchorPoint()) {
             case TOP_LEFT -> new Coordinate2D(boundsInScene.getMinX(), boundsInScene.getMinY());
             case TOP_CENTER -> new Coordinate2D(boundsInScene.getCenterX(), boundsInScene.getMinY());
             case TOP_RIGHT -> new Coordinate2D(boundsInScene.getMaxX(), boundsInScene.getMinY());
@@ -375,7 +375,5 @@ public abstract class YaegerEntity implements Initializable, TimerListProvider, 
             case BOTTOM_CENTER -> new Coordinate2D(boundsInScene.getCenterX(), boundsInScene.getMaxY());
             case BOTTOM_RIGHT -> new Coordinate2D(boundsInScene.getMaxX(), boundsInScene.getMaxY());
         };
-
-        return absoluteLocation;
     }
 }

--- a/src/test/java/com/github/hanyaeger/api/engine/entities/entity/YaegerEntityTest.java
+++ b/src/test/java/com/github/hanyaeger/api/engine/entities/entity/YaegerEntityTest.java
@@ -14,9 +14,13 @@ import javafx.scene.Scene;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -45,8 +49,11 @@ class YaegerEntityTest {
         var boundingBox = mock(BoundingBox.class);
 
         when(node.getBoundsInLocal()).thenReturn(boundingBox);
+        when(node.localToScene(boundingBox, true)).thenReturn(boundingBox);
         when(boundingBox.getWidth()).thenReturn(ENTITY_WIDTH);
         when(boundingBox.getHeight()).thenReturn(ENTITY_HEIGHT);
+        when(boundingBox.getMinX()).thenReturn(LOCATION.getX());
+        when(boundingBox.getMinY()).thenReturn(LOCATION.getY());
         when(node.getScene()).thenReturn(scene);
         when(scene.getWidth()).thenReturn(SCENE_WIDTH);
     }
@@ -624,15 +631,18 @@ class YaegerEntityTest {
         assertThrows(NullPointerException.class, () -> sut.angleTo(other));
     }
 
-    @Test
-    void angleToYaegerEntityVerticallyAboveIs180Degrees() {
+    @ParameterizedTest
+    @MethodSource("provideArgumentsForAngleTo")
+    void testAngleToOtherEntity(Coordinate2D otherLocation, double expectedAngle) {
         // Arrange
-        var expected = Direction.UP.getValue();
-        var other = new YaegerEntityImpl(new Coordinate2D(LOCATION.getX(), LOCATION.getY() - 10));
+        var other = new YaegerEntityImpl(otherLocation);
         var otherNode = mock(Node.class, withSettings().withoutAnnotations());
         other.setNode(Optional.of(otherNode));
         var otherBoundingBox = mock(BoundingBox.class);
+        when(otherNode.localToScene(otherBoundingBox, true)).thenReturn(otherBoundingBox);
         when(otherNode.getBoundsInLocal()).thenReturn(otherBoundingBox);
+        when(otherBoundingBox.getMinX()).thenReturn(otherLocation.getX());
+        when(otherBoundingBox.getMinY()).thenReturn(otherLocation.getY());
         when(otherBoundingBox.getWidth()).thenReturn(ENTITY_WIDTH);
         when(otherBoundingBox.getHeight()).thenReturn(ENTITY_HEIGHT);
         when(otherNode.getScene()).thenReturn(scene);
@@ -648,317 +658,21 @@ class YaegerEntityTest {
         var actual = sut.angleTo(other);
 
         // Assert
-        assertEquals(expected, actual);
+        assertEquals(expectedAngle, actual);
     }
 
-    @Test
-    void angleToYaegerEntityVerticallyBelowIs0Degrees() {
+    @ParameterizedTest
+    @MethodSource("provideArgumentsForAngleTo")
+    void testAngleToOtherLocation(Coordinate2D otherLocation, double expectedAngle) {
         // Arrange
-        var expected = Direction.DOWN.getValue();
-        var other = new YaegerEntityImpl(new Coordinate2D(LOCATION.getX(), LOCATION.getY() + 10));
-        var otherNode = mock(Node.class, withSettings().withoutAnnotations());
-        other.setNode(Optional.of(otherNode));
-        var otherBoundingBox = mock(BoundingBox.class);
-        when(otherNode.getBoundsInLocal()).thenReturn(otherBoundingBox);
-        when(otherBoundingBox.getWidth()).thenReturn(ENTITY_WIDTH);
-        when(otherBoundingBox.getHeight()).thenReturn(ENTITY_HEIGHT);
-        when(otherNode.getScene()).thenReturn(scene);
-        when(scene.getWidth()).thenReturn(SCENE_WIDTH);
-
-        other.init(injector);
-        other.transferCoordinatesToNode();
-
         sut.init(injector);
         sut.transferCoordinatesToNode();
 
         // Act
-        var actual = sut.angleTo(other);
+        var actual = sut.angleTo(otherLocation);
 
         // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToYaegerEntityHorizontallyLeftIs270Degrees() {
-        // Arrange
-        var expected = Direction.LEFT.getValue();
-        var other = new YaegerEntityImpl(new Coordinate2D(LOCATION.getX() - 10, LOCATION.getY()));
-        var otherNode = mock(Node.class, withSettings().withoutAnnotations());
-        other.setNode(Optional.of(otherNode));
-        var otherBoundingBox = mock(BoundingBox.class);
-        when(otherNode.getBoundsInLocal()).thenReturn(otherBoundingBox);
-        when(otherBoundingBox.getWidth()).thenReturn(ENTITY_WIDTH);
-        when(otherBoundingBox.getHeight()).thenReturn(ENTITY_HEIGHT);
-        when(otherNode.getScene()).thenReturn(scene);
-        when(scene.getWidth()).thenReturn(SCENE_WIDTH);
-
-        other.init(injector);
-        other.transferCoordinatesToNode();
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(other);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToYaegerEntityHorizontallyRightIs90Degrees() {
-        // Arrange
-        var expected = Direction.RIGHT.getValue();
-        var other = new YaegerEntityImpl(new Coordinate2D(LOCATION.getX() + 10, LOCATION.getY()));
-        var otherNode = mock(Node.class, withSettings().withoutAnnotations());
-        other.setNode(Optional.of(otherNode));
-        var otherBoundingBox = mock(BoundingBox.class);
-        when(otherNode.getBoundsInLocal()).thenReturn(otherBoundingBox);
-        when(otherBoundingBox.getWidth()).thenReturn(ENTITY_WIDTH);
-        when(otherBoundingBox.getHeight()).thenReturn(ENTITY_HEIGHT);
-        when(otherNode.getScene()).thenReturn(scene);
-        when(scene.getWidth()).thenReturn(SCENE_WIDTH);
-
-        other.init(injector);
-        other.transferCoordinatesToNode();
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(other);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToYaegerEntityLeftAboveIs225Degrees() {
-        // Arrange
-        var expected = 225d;
-        var other = new YaegerEntityImpl(new Coordinate2D(LOCATION.getX() - 10, LOCATION.getY() - 10));
-        var otherNode = mock(Node.class, withSettings().withoutAnnotations());
-        other.setNode(Optional.of(otherNode));
-        var otherBoundingBox = mock(BoundingBox.class);
-        when(otherNode.getBoundsInLocal()).thenReturn(otherBoundingBox);
-        when(otherBoundingBox.getWidth()).thenReturn(ENTITY_WIDTH);
-        when(otherBoundingBox.getHeight()).thenReturn(ENTITY_HEIGHT);
-        when(otherNode.getScene()).thenReturn(scene);
-        when(scene.getWidth()).thenReturn(SCENE_WIDTH);
-
-        other.init(injector);
-        other.transferCoordinatesToNode();
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(other);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToYaegerEntityRightAboveIs135Degrees() {
-        // Arrange
-        var expected = 135d;
-        var other = new YaegerEntityImpl(new Coordinate2D(LOCATION.getX() + 10, LOCATION.getY() - 10));
-
-        other.init(injector);
-        other.transferCoordinatesToNode();
-        other.applyTranslationsForAnchorPoint();
-
-        sut.transferCoordinatesToNode();
-        sut.applyTranslationsForAnchorPoint();
-
-        // Act
-        var actual = sut.angleTo(other);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToYaegerEntityLeftBelowIs315Degrees() {
-        // Arrange
-        var expected = 315d;
-        var other = new YaegerEntityImpl(new Coordinate2D(LOCATION.getX() - 10, LOCATION.getY() + 10));
-        var otherNode = mock(Node.class, withSettings().withoutAnnotations());
-        other.setNode(Optional.of(otherNode));
-        var otherBoundingBox = mock(BoundingBox.class);
-        when(otherNode.getBoundsInLocal()).thenReturn(otherBoundingBox);
-        when(otherBoundingBox.getWidth()).thenReturn(ENTITY_WIDTH);
-        when(otherBoundingBox.getHeight()).thenReturn(ENTITY_HEIGHT);
-        when(otherNode.getScene()).thenReturn(scene);
-        when(scene.getWidth()).thenReturn(SCENE_WIDTH);
-
-        other.init(injector);
-        other.transferCoordinatesToNode();
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(other);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToYaegerEntityRightBelowIs45Degrees() {
-        // Arrange
-        var expected = 45d;
-        var other = new YaegerEntityImpl(new Coordinate2D(LOCATION.getX() + 10, LOCATION.getY() + 10));
-        var otherNode = mock(Node.class, withSettings().withoutAnnotations());
-        other.setNode(Optional.of(otherNode));
-        var otherBoundingBox = mock(BoundingBox.class);
-        when(otherNode.getBoundsInLocal()).thenReturn(otherBoundingBox);
-        when(otherBoundingBox.getWidth()).thenReturn(ENTITY_WIDTH);
-        when(otherBoundingBox.getHeight()).thenReturn(ENTITY_HEIGHT);
-        when(otherNode.getScene()).thenReturn(scene);
-        when(scene.getWidth()).thenReturn(SCENE_WIDTH);
-
-        other.init(injector);
-        other.transferCoordinatesToNode();
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(other);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToCoordinate2DVerticallyAboveIs180Degrees() {
-        // Arrange
-        var expected = Direction.UP.getValue();
-        var above = new Coordinate2D(LOCATION.getX(), LOCATION.getY() - 10);
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(above);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToCoordinate2DVerticallyBelowIs0Degrees() {
-        // Arrange
-        var expected = Direction.DOWN.getValue();
-        var below = new Coordinate2D(LOCATION.getX(), LOCATION.getY() + 10);
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(below);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToCoordinate2DHorizontallyLeftIs270Degrees() {
-        // Arrange
-        var expected = Direction.LEFT.getValue();
-        var left = new Coordinate2D(LOCATION.getX() - 10, LOCATION.getY());
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(left);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToCoordinate2DHorizontallyRightIs90Degrees() {
-        // Arrange
-        var expected = Direction.RIGHT.getValue();
-        var right = new Coordinate2D(LOCATION.getX() + 10, LOCATION.getY());
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(right);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToCoordinate2DLeftAboveIs225Degrees() {
-        // Arrange
-        var expected = 225;
-        var leftAbove = new Coordinate2D(LOCATION.getX() - 100, LOCATION.getY() - 100);
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(leftAbove);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToCoordinate2DRightAboveIs135Degrees() {
-        // Arrange
-        var expected = 135d;
-        var rightAbove = new Coordinate2D(LOCATION.getX() + 10, LOCATION.getY() - 10);
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(rightAbove);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToCoordinate2DLeftBelowIs315Degrees() {
-        // Arrange
-        var expected = 315d;
-        var leftBelow = new Coordinate2D(LOCATION.getX() - 10, LOCATION.getY() + 10);
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(leftBelow);
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    void angleToCoordinate2DRightBelowIs45Degrees() {
-        // Arrange
-        var expected = 45d;
-        var rightBelow = new Coordinate2D(LOCATION.getX() + 10, LOCATION.getY() + 10);
-
-        sut.init(injector);
-        sut.transferCoordinatesToNode();
-
-        // Act
-        var actual = sut.angleTo(rightBelow);
-
-        // Assert
-        assertEquals(expected, actual);
+        assertEquals(expectedAngle, actual);
     }
 
     @Test
@@ -997,6 +711,20 @@ class YaegerEntityTest {
 
         // Assert
         Assertions.assertEquals(sut, entityProcessor.processedEntity);
+    }
+
+    private static Stream<Arguments> provideArgumentsForAngleTo() {
+        return Stream.of(
+                Arguments.of(new Coordinate2D(LOCATION.getX(), LOCATION.getY() - 10), Direction.UP.getValue()),
+                Arguments.of(new Coordinate2D(LOCATION.getX(), LOCATION.getY() + 10), Direction.DOWN.getValue()),
+                Arguments.of(new Coordinate2D(LOCATION.getX() - 10, LOCATION.getY()), Direction.LEFT.getValue()),
+                Arguments.of(new Coordinate2D(LOCATION.getX() + 10, LOCATION.getY()), Direction.RIGHT.getValue()),
+                Arguments.of(new Coordinate2D(LOCATION.getX() - 10, LOCATION.getY() - 10), 225d), // left above
+                Arguments.of(new Coordinate2D(LOCATION.getX() + 10, LOCATION.getY() - 10), 135d), // right above
+                Arguments.of(new Coordinate2D(LOCATION.getX() - 10, LOCATION.getY() + 10), 315d), // left below
+                Arguments.of(new Coordinate2D(LOCATION.getX() + 10, LOCATION.getY() + 10), 45d) // right below
+
+        );
     }
 
     private static class YaegerEntityImpl extends YaegerEntity {

--- a/src/test/java/com/github/hanyaeger/api/engine/entities/entity/YaegerEntityTest.java
+++ b/src/test/java/com/github/hanyaeger/api/engine/entities/entity/YaegerEntityTest.java
@@ -663,7 +663,7 @@ class YaegerEntityTest {
 
     @ParameterizedTest
     @MethodSource("provideArgumentsForAngleTo")
-    void testAngleToOtherLocation(Coordinate2D otherLocation, double expectedAngle) {
+    void testAngleToOtherLocation(final Coordinate2D otherLocation, final double expectedAngle) {
         // Arrange
         sut.init(injector);
         sut.transferCoordinatesToNode();
@@ -673,6 +673,23 @@ class YaegerEntityTest {
 
         // Assert
         assertEquals(expectedAngle, actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideArgumentsForGetLocationInScene")
+    void testGetLocationInScene(AnchorPoint anchorPoint, double expectedX, double expectedY) {
+        // Arrange
+        var boundingBox = new BoundingBox(LOCATION.getX(), LOCATION.getY(), ENTITY_WIDTH, ENTITY_HEIGHT);
+        when(node.localToScene(boundingBox, true)).thenReturn(boundingBox);
+        when(node.getBoundsInLocal()).thenReturn(boundingBox);
+        sut.setAnchorPoint(anchorPoint);
+        var expected = new Coordinate2D(expectedX, expectedY);
+
+        // Act
+        var actual = sut.getLocationInScene();
+
+        // Assert
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -726,6 +743,21 @@ class YaegerEntityTest {
 
         );
     }
+
+    private static Stream<Arguments> provideArgumentsForGetLocationInScene() {
+        return Stream.of(
+                Arguments.of(AnchorPoint.TOP_LEFT, LOCATION.getX(), LOCATION.getY()),
+                Arguments.of(AnchorPoint.TOP_CENTER, LOCATION.getX() + ENTITY_WIDTH / 2, LOCATION.getY()),
+                Arguments.of(AnchorPoint.TOP_RIGHT, LOCATION.getX() + ENTITY_WIDTH, LOCATION.getY()),
+                Arguments.of(AnchorPoint.CENTER_LEFT, LOCATION.getX(), LOCATION.getY() + ENTITY_HEIGHT / 2),
+                Arguments.of(AnchorPoint.CENTER_CENTER, LOCATION.getX() + ENTITY_WIDTH / 2, LOCATION.getY() + ENTITY_HEIGHT / 2),
+                Arguments.of(AnchorPoint.CENTER_RIGHT, LOCATION.getX() + ENTITY_WIDTH, LOCATION.getY() + ENTITY_HEIGHT / 2),
+                Arguments.of(AnchorPoint.BOTTOM_LEFT, LOCATION.getX(), LOCATION.getY() + ENTITY_HEIGHT),
+                Arguments.of(AnchorPoint.BOTTOM_CENTER, LOCATION.getX() + ENTITY_WIDTH / 2, LOCATION.getY() + ENTITY_HEIGHT),
+                Arguments.of(AnchorPoint.BOTTOM_RIGHT, LOCATION.getX() + ENTITY_WIDTH, LOCATION.getY() + ENTITY_HEIGHT)
+        );
+    }
+
 
     private static class YaegerEntityImpl extends YaegerEntity {
 


### PR DESCRIPTION
Fixes #160 

Initially I implemented this by storing a _referencePoint_ inside a Coordinate2D which stores the coordinates a Coordinate2D is based on. Thanks to @meronbrouwer 's suggestion I was able to solve it in a much cleaner and simpler way.

I also added junit-params, because I noticed a lot of the angleTo tests were testing exactly the same, but with different parameters. This dependency makes it possible to easily test a method with a lot of different arguments. I cleaned up the angleTo tests, but I think it can also be used for a lot of the other tests.