### PR TITLE
Full ColorAdjust for YaegerScenes and YaegerEntities

### DIFF
--- a/src/main/java/com/github/hanyaeger/api/entities/YaegerEntity.java
+++ b/src/main/java/com/github/hanyaeger/api/entities/YaegerEntity.java
@@ -3,6 +3,7 @@ package com.github.hanyaeger.api.entities;
 import com.github.hanyaeger.api.AnchorPoint;
 import com.github.hanyaeger.api.Coordinate2D;
 import com.github.hanyaeger.api.YaegerGame;
+import com.github.hanyaeger.core.Effectable;
 import com.github.hanyaeger.core.Initializable;
 import com.github.hanyaeger.api.Timer;
 import com.github.hanyaeger.core.TimerListProvider;
@@ -14,6 +15,7 @@ import javafx.event.EventType;
 import javafx.geometry.Point2D;
 import javafx.scene.Cursor;
 import javafx.scene.Node;
+import javafx.scene.effect.ColorAdjust;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +25,7 @@ import java.util.Optional;
  * A {@link YaegerEntity} is the base class for all things that can be drawn on a
  * {@link com.github.hanyaeger.core.scenes.YaegerScene}.
  */
-public abstract class YaegerEntity implements Initializable, TimerListProvider, Bounded, Removable, Placeable, SceneChild, GameNode, Rotatable, EventInitiator {
+public abstract class YaegerEntity implements Initializable, TimerListProvider, Bounded, Removable, Placeable, SceneChild, GameNode, Rotatable, EventInitiator, Effectable {
 
     static final boolean DEFAULT_VISIBILITY = true;
     static final double DEFAULT_OPACITY = 1;
@@ -38,6 +40,8 @@ public abstract class YaegerEntity implements Initializable, TimerListProvider, 
     private final List<Timer> timers = new ArrayList<>();
 
     private final RotationBuffer rotationBuffer;
+
+    private final ColorAdjust colorAdjust = new ColorAdjust();
 
     /**
      * Create a new {@link YaegerEntity} on the given {@link Coordinate2D}.
@@ -277,6 +281,7 @@ public abstract class YaegerEntity implements Initializable, TimerListProvider, 
 
     @Override
     public void init(final Injector injector) {
+        getNode().ifPresent(Node -> getNode().get().setEffect(colorAdjust));
         setVisible(visible);
         setOpacity(opacity);
         cursor.ifPresent(this::setCursor);
@@ -312,6 +317,46 @@ public abstract class YaegerEntity implements Initializable, TimerListProvider, 
     @Override
     public void setAnchorLocationY(final double y) {
         setAnchorLocation(new Coordinate2D(getAnchorLocation().getX(), y));
+    }
+
+    @Override
+    public void setBrightness(final double brightness) {
+        colorAdjust.setBrightness(brightness);
+    }
+
+    @Override
+    public void setContrast(final double contrast) {
+        colorAdjust.setContrast(contrast);
+    }
+
+    @Override
+    public void setHue(final double hue) {
+        colorAdjust.setHue(hue);
+    }
+
+    @Override
+    public void setSaturation(final double saturation) {
+        colorAdjust.setSaturation(saturation);
+    }
+
+    @Override
+    public double getBrightness() {
+        return colorAdjust.getBrightness();
+    }
+
+    @Override
+    public double getContrast() {
+        return colorAdjust.getContrast();
+    }
+
+    @Override
+    public double getHue() {
+        return colorAdjust.getHue();
+    }
+
+    @Override
+    public double getSaturation() {
+        return colorAdjust.getSaturation();
     }
 
     @Override

--- a/src/main/java/com/github/hanyaeger/api/scenes/StaticScene.java
+++ b/src/main/java/com/github/hanyaeger/api/scenes/StaticScene.java
@@ -162,15 +162,44 @@ public abstract class StaticScene implements YaegerScene, SupplierProvider, Tile
         backgroundDelegate.setBackgroundAudio(url);
     }
 
-
     @Override
     public void setBrightness(final double brightness) {
         colorAdjust.setBrightness(brightness);
     }
 
     @Override
+    public void setContrast(final double contrast) {
+        colorAdjust.setContrast(contrast);
+    }
+
+    @Override
+    public void setHue(final double hue) {
+        colorAdjust.setHue(hue);
+    }
+
+    @Override
+    public void setSaturation(final double saturation) {
+        colorAdjust.setSaturation(saturation);
+    }
+
+    @Override
     public double getBrightness() {
         return colorAdjust.getBrightness();
+    }
+
+    @Override
+    public double getContrast() {
+        return colorAdjust.getContrast();
+    }
+
+    @Override
+    public double getHue() {
+        return colorAdjust.getHue();
+    }
+
+    @Override
+    public double getSaturation() {
+        return colorAdjust.getSaturation();
     }
 
     @Override

--- a/src/main/java/com/github/hanyaeger/core/Effectable.java
+++ b/src/main/java/com/github/hanyaeger/core/Effectable.java
@@ -12,7 +12,7 @@ import com.github.hanyaeger.core.scenes.YaegerScene;
 public interface Effectable {
 
     /**
-     * Set the brightness of the whole {@link YaegerScene}. The value should be a value between
+     * Set the brightness of the {@link YaegerScene} or {@link YaegerEntity}. The value should be a value between
      * -1 and 1, inclusive.
      * <p>
      * The brightness adjustment value.
@@ -21,12 +21,12 @@ public interface Effectable {
      *      Max: +1.0 Fully bright
      * </pre>
      *
-     * @param brightness the brightness as a {@code double}, between 0 and 1
+     * @param brightness the brightness as a {@code double}, between -1 and 1
      */
     void setBrightness(final double brightness);
 
     /**
-     * Return the brightness level of this scene. Brightness is a {@code double}
+     * Return the brightness level of this {@link YaegerScene} or {@link YaegerEntity}. Brightness is a {@code double}
      * between -1 and 1, where
      * <pre>
      *      Min: -1.0 Completely dark
@@ -36,4 +36,82 @@ public interface Effectable {
      * @return The brightness as a {@code double}.
      */
     double getBrightness();
+
+    /**
+     * Set the contrast of the {@link YaegerScene} or {@link YaegerEntity}. The value should be a value between
+     * -1 and 1, inclusive.
+     * <p>
+     * The contrast adjustment value.
+     * <pre>
+     *      Min: -1.0 No contrast
+     *      Max: +1.0 Maximum contrast
+     * </pre>
+     *
+     * @param contrast the contrast as a {@code double}, between -1 and 1
+     */
+    void setContrast(final double contrast);
+
+    /**
+     * Return the contrast level of this {@link YaegerScene} or {@link YaegerEntity}. Contrast is a {@code double}
+     * between -1 and 1, where
+     * <pre>
+     *      Min: -1.0 No contrast
+     *      Max: +1.0 Maximum contrast
+     * </pre>
+     *
+     * @return The contrast as a {@code double}.
+     */
+    double getContrast();
+
+    /**
+     * Set the hue of the {@link YaegerScene} or {@link YaegerEntity}. The value should be a value between
+     * -1 and 1, inclusive.
+     * <p>
+     * The contrast adjustment value.
+     * <pre>
+     *      Min: -1.0 Minimum hue
+     *      Max: +1.0 Maximum hue
+     * </pre>
+     *
+     * @param hue the hue as a {@code double}, between -1 and 1
+     */
+    void setHue(final double hue);
+
+    /**
+     * Return the contrast level of this {@link YaegerScene} or {@link YaegerEntity}. Hue is a {@code double}
+     * between -1 and 1, where
+     * <pre>
+     *      Min: -1.0 Minimum hue
+     *      Max: +1.0 Maximum hue
+     * </pre>
+     *
+     * @return The contrast as a {@code double}.
+     */
+    double getHue();
+
+    /**
+     * Set the saturation of the {@link YaegerScene} or {@link YaegerEntity}. The value should be a value between
+     * -1 and 1, inclusive.
+     * <p>
+     * The contrast adjustment value.
+     * <pre>
+     *      Min: -1.0 Minimum saturation
+     *      Max: +1.0 Maximum saturation
+     * </pre>
+     *
+     * @param saturation the saturation as a {@code double}, between -1 and 1
+     */
+    void setSaturation(final double saturation);
+
+    /**
+     * Return the saturation level of this {@link YaegerScene} or {@link YaegerEntity}. Saturation is a {@code double}
+     * between -1 and 1, where
+     * <pre>
+     *      Min: -1.0 Minimum saturation
+     *      Max: +1.0 Maximum saturation
+     * </pre>
+     *
+     * @return The saturation as a {@code double}.
+     */
+    double getSaturation();
 }


### PR DESCRIPTION
As noted in #92, ColorAdjust was not fully implemented for scenes and entities. Since I needed this behaviour I added it. I did not include any unittests, but to compensate a little I did write the javadoc.